### PR TITLE
Chop long names at 32 characters

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 resource "aws_alb" "alb" {
-  name            = "${var.name}"
+  name            = "${join("", slice(split("", var.name), 0, length(var.name) > 31 ? 32 : length(var.name)))}"
   internal        = "${var.internal}"
   security_groups = ["${concat(list(aws_security_group.default.id), var.extra_security_groups)}"]
   subnets         = "${var.subnet_ids}"

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,1 +1,2 @@
+hypothesis==3.11.1
 pytest==3.0.7

--- a/test/test_tf_alb.py
+++ b/test/test_tf_alb.py
@@ -1,7 +1,10 @@
-import unittest
 import os
-import time
+import unittest
+from string import ascii_letters, digits
 from subprocess import check_call, check_output
+
+from hypothesis import given, settings
+from hypothesis.strategies import text
 
 cwd = os.getcwd()
 
@@ -11,10 +14,10 @@ class TestTFALB(unittest.TestCase):
     def setUp(self):
         check_call(['terraform', 'get', 'test/infra'])
 
-    def test_create_alb(self):
+    @given(text(alphabet=ascii_letters + digits, min_size=24, max_size=36))
+    @settings(max_examples=20, timeout=15)
+    def test_create_alb(self, name):
         # Given
-        # ms since epoch
-        name = 'test-' + str(int(time.time() * 1000))
         subnet_ids = (
             "[\"subnet-b46032ec\", \"subnet-ca4311ef\", \"subnet-ba881221\"]"
         )
@@ -50,7 +53,7 @@ class TestTFALB(unittest.TestCase):
     subnets.416118645:          "subnet-b46032ec"
     vpc_id:                     "<computed>"
     zone_id:                    "<computed>"
-        """.format(name=name).strip() in output
+        """.format(name=name[:32]).strip() in output
 
     def test_create_listener(self):
         # Given


### PR DESCRIPTION
ALB name cannot be longer then 32 characters; chop them at 32 characters
if passed name is longer.

Also, modified test to cover this case (using Hypothesis); it takes a
bit longer, but covers more.