### PR TITLE
Tag created resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Module Input Variables
 - `certificate_arn` - (string) - **REQUIRED** - The ARN of the SSL server certificate. Exactly one certificate is required if the protocol is HTTPS
 - `default_target_group_arn` - (string) - **REQUIRED** - The ARN of the default Target Group to which to route traffic
 - `internal` - (bool) - OPTIONAL - If true, the ALB will be internal; default: `true`
-- `extra_security_groups` - list - OPTIONAL - Extra security groups to be attached to ALB
+- `extra_security_groups` - (list) - OPTIONAL - Extra security groups to be attached to ALB
+- `tags` - (map) - OPTIONAL - Map of tags to be applied to the resources (just to ALB as ALB Listeners cannot be tagged); default: `{}` (empty - no tags)
 
 Usage
 -----

--- a/main.tf
+++ b/main.tf
@@ -3,6 +3,7 @@ resource "aws_alb" "alb" {
   internal        = "${var.internal}"
   security_groups = ["${concat(list(aws_security_group.default.id), var.extra_security_groups)}"]
   subnets         = "${var.subnet_ids}"
+  tags            = "${var.tags}"
 }
 
 resource "aws_alb_listener" "https" {

--- a/test/infra/main.tf
+++ b/test/infra/main.tf
@@ -10,6 +10,21 @@ module "alb_test" {
   default_target_group_arn = "${var.default_target_group_arn}"
 }
 
+module "alb_test_with_tags" {
+  source = "../.."
+
+  # required
+  name                     = "${var.name}"
+  vpc_id                   = "${var.vpc_id}"
+  subnet_ids               = "${var.subnet_ids}"
+  certificate_arn          = "${var.certificate_arn}"
+  default_target_group_arn = "${var.default_target_group_arn}"
+  tags {
+    component = "component"
+    service   = "service"
+  }
+}
+
 # configure provider to not try too hard talking to AWS API
 provider "aws" {
   skip_credentials_validation = true

--- a/test/test_tf_alb.py
+++ b/test/test_tf_alb.py
@@ -63,6 +63,49 @@ class TestTFALB(unittest.TestCase):
     zone_id:                    "<computed>"
         """.format(name=name[:32].strip('-')).strip() in output
 
+    def test_create_alb_with_tags(self):
+        # Given
+        subnet_ids = (
+            "[\"subnet-b46032ec\", \"subnet-ca4311ef\", \"subnet-ba881221\"]"
+        )
+
+        # When
+        output = check_output([
+            'terraform',
+            'plan',
+            '-var', 'name=albalbalb',
+            '-var', 'vpc_id=foobar',
+            '-var', 'subnet_ids={}'.format(subnet_ids),
+            '-var', 'certificate_arn=foobar',
+            '-var', 'default_target_group_arn=foobar',
+            '-target=module.alb_test_with_tags',
+            '-no-color',
+            'test/infra'
+        ]).decode('utf-8')
+
+        # Then
+        assert """
++ module.alb_test_with_tags.aws_alb.alb
+    arn:                        "<computed>"
+    arn_suffix:                 "<computed>"
+    dns_name:                   "<computed>"
+    enable_deletion_protection: "false"
+    idle_timeout:               "60"
+    internal:                   "true"
+    ip_address_type:            "<computed>"
+    name:                       "albalbalb"
+    security_groups.#:          "<computed>"
+    subnets.#:                  "3"
+        """.strip() in output
+
+        assert """
+    tags.%:                     "2"
+    tags.component:             "component"
+    tags.service:               "service"
+    vpc_id:                     "<computed>"
+    zone_id:                    "<computed>"
+        """.strip() in output
+
     def test_create_listener(self):
         # Given
         certificate_arn = (

--- a/variables.tf
+++ b/variables.tf
@@ -36,3 +36,8 @@ variable "extra_security_groups" {
   type        = "list"
   default     = [""]
 }
+
+variable "tags" {
+  description = "A map of tags to add to all resources"
+  default     = {}
+}


### PR DESCRIPTION
We'd like to be able to tag created resources (just ALB as ALB Listeners cannot be tagged) to allow easier identification if it's needed.

JIRA: PLAT-798