### PR TITLE
Use data source to resolve AWS ACM Certificate ARN

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Module Input Variables
 - `name` - (string) - **REQUIRED** - The name of the ALB. This name must be unique within your AWS account, can have a maximum of 32 characters, must contain only alphanumeric characters or hyphens, and must not begin or end with a hyphen
 - `vpc_id` - (string) - **REQUIRED** - The id of the VPC that the ALB should be placed in
 - `subnet_ids` - (list) - **REQUIRED** - A list of subnet IDs to attach to the ALB
-- `certificate_arn` - (string) - **REQUIRED** - The ARN of the SSL server certificate. Exactly one certificate is required if the protocol is HTTPS
+- `certificate_domain_name` - (string) - **REQUIRED** - Domain name as used in AWS ACM Certificate - this will be used by Terraform Data Source to resolve the actual certificate ARN
 - `default_target_group_arn` - (string) - **REQUIRED** - The ARN of the default Target Group to which to route traffic
 - `internal` - (bool) - OPTIONAL - If true, the ALB will be internal; default: `true`
 - `extra_security_groups` - (list) - OPTIONAL - Extra security groups to be attached to ALB
@@ -30,8 +30,8 @@ module "alb_test" {
   name                     = "foobar-alb"
   vpc_id                   = "vpc-2f09a348"
   subnet_ids               = ["subnet-b46032ec", "subnet-ca4311ef", "subnet-ba881221"]
-  certificate_arn          = "arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012"
   default_target_group_arn = "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/my-targets/73e2d6bc24d8a067"
+  certificate_domain_name  = "*.acuris.com"
 }
 ```
 

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,9 @@
+module "aws_acm_certificate_arn" {
+  source = "./modules/aws_acm_certificate_arn"
+
+  domain_name = "${var.certificate_domain_name}"
+}
+
 resource "aws_alb" "alb" {
   name            = "${replace(replace(var.name, "/(.{0,32}).*/", "$1"), "/^-+|-+$/", "")}"
   internal        = "${var.internal}"
@@ -10,7 +16,7 @@ resource "aws_alb_listener" "https" {
   load_balancer_arn = "${aws_alb.alb.arn}"
   port              = "443"
   protocol          = "HTTPS"
-  certificate_arn   = "${var.certificate_arn}"
+  certificate_arn   = "${module.aws_acm_certificate_arn.arn}"
 
   default_action {
     target_group_arn = "${var.default_target_group_arn}"

--- a/modules/aws_acm_certificate_arn/main.tf
+++ b/modules/aws_acm_certificate_arn/main.tf
@@ -1,0 +1,13 @@
+data "aws_acm_certificate" "cert" {
+  domain   = "${var.domain_name}"
+  statuses = ["ISSUED"]
+}
+
+variable "domain_name" {
+  description = ""
+  type = "string"
+}
+
+output "arn" {
+  value = "${data.aws_acm_certificate.cert.arn}"
+}

--- a/test/infra/main.tf
+++ b/test/infra/main.tf
@@ -6,7 +6,7 @@ module "alb_test" {
   name                     = "${var.name}"
   vpc_id                   = "${var.vpc_id}"
   subnet_ids               = "${var.subnet_ids}"
-  certificate_arn          = "${var.certificate_arn}"
+  certificate_domain_name  = "${var.certificate_domain_name}"
   default_target_group_arn = "${var.default_target_group_arn}"
 }
 
@@ -17,8 +17,9 @@ module "alb_test_with_tags" {
   name                     = "${var.name}"
   vpc_id                   = "${var.vpc_id}"
   subnet_ids               = "${var.subnet_ids}"
-  certificate_arn          = "${var.certificate_arn}"
+  certificate_domain_name  = "${var.certificate_domain_name}"
   default_target_group_arn = "${var.default_target_group_arn}"
+
   tags {
     component = "component"
     service   = "service"
@@ -47,6 +48,8 @@ variable "subnet_ids" {
   type = "list"
 }
 
-variable "certificate_arn" {}
+variable "certificate_domain_name" {
+  default = "dummydomain.com"
+}
 
 variable "default_target_group_arn" {}

--- a/test/test_tf_alb.py
+++ b/test/test_tf_alb.py
@@ -1,4 +1,3 @@
-import os
 import unittest
 from string import ascii_letters, digits
 from subprocess import check_call, check_output
@@ -37,8 +36,8 @@ class TestTFALB(unittest.TestCase):
             '-var', 'name={}'.format(name),
             '-var', 'vpc_id=foobar',
             '-var', 'subnet_ids={}'.format(subnet_ids),
-            '-var', 'certificate_arn=foobar',
             '-var', 'default_target_group_arn=foobar',
+            '-target=module.alb_test',
             '-no-color',
             'test/infra'
         ]).decode('utf-8')
@@ -76,7 +75,6 @@ class TestTFALB(unittest.TestCase):
             '-var', 'name=albalbalb',
             '-var', 'vpc_id=foobar',
             '-var', 'subnet_ids={}'.format(subnet_ids),
-            '-var', 'certificate_arn=foobar',
             '-var', 'default_target_group_arn=foobar',
             '-target=module.alb_test_with_tags',
             '-no-color',
@@ -108,10 +106,6 @@ class TestTFALB(unittest.TestCase):
 
     def test_create_listener(self):
         # Given
-        certificate_arn = (
-            "arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234"
-            "-1234-123456789012"
-        )
         default_target_group_arn = (
             "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/"
             "my-targets/73e2d6bc24d8a067"
@@ -124,10 +118,11 @@ class TestTFALB(unittest.TestCase):
             '-var', 'name=foobar',
             '-var', 'vpc_id=foobar',
             '-var', 'subnet_ids=["foo", "bar", "foo"]',
-            '-var', 'certificate_arn={}'.format(certificate_arn),
+            '-var', 'certificate_domain_name=foobar.com',
             '-var', 'default_target_group_arn={}'.format(
                 default_target_group_arn
             ),
+            '-target=module.alb_test',
             '-no-color',
             'test/infra'
         ]).decode('utf-8')
@@ -136,7 +131,7 @@ class TestTFALB(unittest.TestCase):
         assert """
 + module.alb_test.aws_alb_listener.https
     arn:                               "<computed>"
-    certificate_arn:                   "arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012"
+    certificate_arn:                   "${module.aws_acm_certificate_arn.arn}"
     default_action.#:                  "1"
     default_action.0.target_group_arn: "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/my-targets/73e2d6bc24d8a067"
     default_action.0.type:             "forward"
@@ -157,8 +152,9 @@ class TestTFALB(unittest.TestCase):
             '-var', 'name=foo',
             '-var', 'vpc_id={}'.format(vpc_id),
             '-var', 'subnet_ids=["foo", "bar", "foo"]',
-            '-var', 'certificate_arn=foobar',
+            '-var', 'certificate_domain_name=foobar.com',
             '-var', 'default_target_group_arn=foobar',
+            '-target=module.alb_test',
             '-no-color',
             'test/infra'
         ]).decode('utf-8')

--- a/variables.tf
+++ b/variables.tf
@@ -14,8 +14,8 @@ variable "subnet_ids" {
   type        = "list"
 }
 
-variable "certificate_arn" {
-  description = "The ARN of the SSL server certificate. Exactly one certificate is required if the protocol is HTTPS"
+variable "certificate_domain_name" {
+  description = "Domain name as used in AWS ACM Certificate - this will be used by Terraform Data Source to resolve the actual certificate ARN"
   type        = "string"
 }
 


### PR DESCRIPTION
We'd like to be able to pass in a domain name for certificate to use and have data-source to resolve its AWS ACM ARN automatically.

We need to wrap it around a module, in order to be able to continue unit-test it.

JIRA: PLAT-1093