### PR TITLE
Add backwards compatible config for access logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Module Input Variables
 - `name` - (string) - **REQUIRED** - The name of the ALB. This name must be unique within your AWS account, can have a maximum of 32 characters, must contain only alphanumeric characters or hyphens, and must not begin or end with a hyphen
 - `vpc_id` - (string) - **REQUIRED** - The id of the VPC that the ALB should be placed in
 - `subnet_ids` - (list) - **REQUIRED** - A list of subnet IDs to attach to the ALB
-- `certificate_arn` - (string) - **REQUIRED** - The ARN of the SSL server certificate. Exactly one certificate is required if the protocol is HTTPS
+- `certificate_domain_name` - (string) - **REQUIRED** - Domain name as used in AWS ACM Certificate - this will be used by Terraform Data Source to resolve the actual certificate ARN
 - `default_target_group_arn` - (string) - **REQUIRED** - The ARN of the default Target Group to which to route traffic
 - `internal` - (bool) - OPTIONAL - If true, the ALB will be internal; default: `true`
 - `extra_security_groups` - (list) - OPTIONAL - Extra security groups to be attached to ALB
@@ -30,8 +30,8 @@ module "alb_test" {
   name                     = "foobar-alb"
   vpc_id                   = "vpc-2f09a348"
   subnet_ids               = ["subnet-b46032ec", "subnet-ca4311ef", "subnet-ba881221"]
-  certificate_arn          = "arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012"
   default_target_group_arn = "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/my-targets/73e2d6bc24d8a067"
+  certificate_domain_name  = "*.acuris.com"
 }
 ```
 

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,9 @@
+module "aws_acm_certificate_arn" {
+  source = "./modules/aws_acm_certificate_arn"
+
+  domain_name = "${var.certificate_domain_name}"
+}
+
 resource "aws_alb" "alb" {
   name            = "${replace(replace(var.name, "/(.{0,32}).*/", "$1"), "/^-+|-+$/", "")}"
   internal        = "${var.internal}"
@@ -16,7 +22,7 @@ resource "aws_alb_listener" "https" {
   load_balancer_arn = "${aws_alb.alb.arn}"
   port              = "443"
   protocol          = "HTTPS"
-  certificate_arn   = "${var.certificate_arn}"
+  certificate_arn   = "${module.aws_acm_certificate_arn.arn}"
 
   default_action {
     target_group_arn = "${var.default_target_group_arn}"

--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,6 @@ resource "aws_alb" "alb" {
 
   access_logs {
     bucket  = "${var.access_logs_bucket}"
-    prefix  = "${var.name}"
     enabled = "${var.access_logs_enabled}"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,12 @@ resource "aws_alb" "alb" {
   security_groups = ["${concat(list(aws_security_group.default.id), var.extra_security_groups)}"]
   subnets         = "${var.subnet_ids}"
   tags            = "${var.tags}"
+
+  access_logs {
+    bucket = "${var.access_logs_bucket}"
+    prefix = "${var.name}"
+    enable = "${var.access_logs_enabled}"
+  }
 }
 
 resource "aws_alb_listener" "https" {

--- a/main.tf
+++ b/main.tf
@@ -12,9 +12,9 @@ resource "aws_alb" "alb" {
   tags            = "${var.tags}"
 
   access_logs {
-    bucket = "${var.access_logs_bucket}"
-    prefix = "${var.name}"
-    enable = "${var.access_logs_enabled}"
+    bucket  = "${var.access_logs_bucket}"
+    prefix  = "${var.name}"
+    enabled = "${var.access_logs_enabled}"
   }
 }
 

--- a/modules/aws_acm_certificate_arn/main.tf
+++ b/modules/aws_acm_certificate_arn/main.tf
@@ -1,0 +1,13 @@
+data "aws_acm_certificate" "cert" {
+  domain   = "${var.domain_name}"
+  statuses = ["ISSUED"]
+}
+
+variable "domain_name" {
+  description = ""
+  type = "string"
+}
+
+output "arn" {
+  value = "${data.aws_acm_certificate.cert.arn}"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,3 +9,7 @@ output "alb_listener_arn" {
 output "alb_arn" {
   value = "${aws_alb.alb.arn}"
 }
+
+output "alb_zone_id" {
+  value = "${aws_alb.alb.zone_id}"
+}

--- a/test/infra/main.tf
+++ b/test/infra/main.tf
@@ -6,7 +6,7 @@ module "alb_test" {
   name                     = "${var.name}"
   vpc_id                   = "${var.vpc_id}"
   subnet_ids               = "${var.subnet_ids}"
-  certificate_arn          = "${var.certificate_arn}"
+  certificate_domain_name  = "${var.certificate_domain_name}"
   default_target_group_arn = "${var.default_target_group_arn}"
 }
 
@@ -17,8 +17,9 @@ module "alb_test_with_tags" {
   name                     = "${var.name}"
   vpc_id                   = "${var.vpc_id}"
   subnet_ids               = "${var.subnet_ids}"
-  certificate_arn          = "${var.certificate_arn}"
+  certificate_domain_name  = "${var.certificate_domain_name}"
   default_target_group_arn = "${var.default_target_group_arn}"
+
   tags {
     component = "component"
     service   = "service"
@@ -47,6 +48,8 @@ variable "subnet_ids" {
   type = "list"
 }
 
-variable "certificate_arn" {}
+variable "certificate_domain_name" {
+  default = "dummydomain.com"
+}
 
 variable "default_target_group_arn" {}

--- a/test/test_tf_alb.py
+++ b/test/test_tf_alb.py
@@ -1,4 +1,3 @@
-import os
 import unittest
 from string import ascii_letters, digits
 from subprocess import check_call, check_output
@@ -37,8 +36,8 @@ class TestTFALB(unittest.TestCase):
             '-var', 'name={}'.format(name),
             '-var', 'vpc_id=foobar',
             '-var', 'subnet_ids={}'.format(subnet_ids),
-            '-var', 'certificate_arn=foobar',
             '-var', 'default_target_group_arn=foobar',
+            '-target=module.alb_test',
             '-no-color',
             'test/infra'
         ]).decode('utf-8')
@@ -76,7 +75,6 @@ class TestTFALB(unittest.TestCase):
             '-var', 'name=albalbalb',
             '-var', 'vpc_id=foobar',
             '-var', 'subnet_ids={}'.format(subnet_ids),
-            '-var', 'certificate_arn=foobar',
             '-var', 'default_target_group_arn=foobar',
             '-target=module.alb_test_with_tags',
             '-no-color',
@@ -108,10 +106,6 @@ class TestTFALB(unittest.TestCase):
 
     def test_create_listener(self):
         # Given
-        certificate_arn = (
-            "arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234"
-            "-1234-123456789012"
-        )
         default_target_group_arn = (
             "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/"
             "my-targets/73e2d6bc24d8a067"
@@ -124,10 +118,11 @@ class TestTFALB(unittest.TestCase):
             '-var', 'name=foobar',
             '-var', 'vpc_id=foobar',
             '-var', 'subnet_ids=["foo", "bar", "foo"]',
-            '-var', 'certificate_arn={}'.format(certificate_arn),
+            '-var', 'certificate_domain_name=foobar.com',
             '-var', 'default_target_group_arn={}'.format(
                 default_target_group_arn
             ),
+            '-target=module.alb_test',
             '-no-color',
             'test/infra'
         ]).decode('utf-8')
@@ -136,7 +131,7 @@ class TestTFALB(unittest.TestCase):
         assert """
 + module.alb_test.aws_alb_listener.https
     arn:                               "<computed>"
-    certificate_arn:                   "arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012"
+    certificate_arn:                   "${module.aws_acm_certificate_arn.arn}"
     default_action.#:                  "1"
     default_action.0.target_group_arn: "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/my-targets/73e2d6bc24d8a067"
     default_action.0.type:             "forward"
@@ -157,8 +152,9 @@ class TestTFALB(unittest.TestCase):
             '-var', 'name=foo',
             '-var', 'vpc_id={}'.format(vpc_id),
             '-var', 'subnet_ids=["foo", "bar", "foo"]',
-            '-var', 'certificate_arn=foobar',
+            '-var', 'certificate_domain_name=foobar.com',
             '-var', 'default_target_group_arn=foobar',
+            '-target=module.alb_test',
             '-no-color',
             'test/infra'
         ]).decode('utf-8')

--- a/test/test_tf_alb.py
+++ b/test/test_tf_alb.py
@@ -45,6 +45,9 @@ class TestTFALB(unittest.TestCase):
         # Then
         assert """
 + module.alb_test.aws_alb.alb
+    access_logs.#:              "1"
+    access_logs.0.enabled:      "false"
+    access_logs.0.prefix:       "{name}"
     arn:                        "<computed>"
     arn_suffix:                 "<computed>"
     dns_name:                   "<computed>"
@@ -52,7 +55,7 @@ class TestTFALB(unittest.TestCase):
     idle_timeout:               "60"
     internal:                   "true"
     ip_address_type:            "<computed>"
-    name:                       "{name}"
+    name:                       "{compact_name}"
     security_groups.#:          "<computed>"
     subnets.#:                  "3"
     subnets.2009589885:         "subnet-ca4311ef"
@@ -60,7 +63,10 @@ class TestTFALB(unittest.TestCase):
     subnets.416118645:          "subnet-b46032ec"
     vpc_id:                     "<computed>"
     zone_id:                    "<computed>"
-        """.format(name=name[:32].strip('-')).strip() in output
+        """.format(
+                compact_name=name[:32].strip('-'),
+                name=name
+            ).strip() in output
 
     def test_create_alb_with_tags(self):
         # Given
@@ -84,6 +90,9 @@ class TestTFALB(unittest.TestCase):
         # Then
         assert """
 + module.alb_test_with_tags.aws_alb.alb
+    access_logs.#:              "1"
+    access_logs.0.enabled:      "false"
+    access_logs.0.prefix:       "albalbalb"
     arn:                        "<computed>"
     arn_suffix:                 "<computed>"
     dns_name:                   "<computed>"

--- a/test/test_tf_alb.py
+++ b/test/test_tf_alb.py
@@ -47,7 +47,6 @@ class TestTFALB(unittest.TestCase):
 + module.alb_test.aws_alb.alb
     access_logs.#:              "1"
     access_logs.0.enabled:      "false"
-    access_logs.0.prefix:       "{name}"
     arn:                        "<computed>"
     arn_suffix:                 "<computed>"
     dns_name:                   "<computed>"
@@ -55,7 +54,7 @@ class TestTFALB(unittest.TestCase):
     idle_timeout:               "60"
     internal:                   "true"
     ip_address_type:            "<computed>"
-    name:                       "{compact_name}"
+    name:                       "{name}"
     security_groups.#:          "<computed>"
     subnets.#:                  "3"
     subnets.2009589885:         "subnet-ca4311ef"
@@ -64,8 +63,7 @@ class TestTFALB(unittest.TestCase):
     vpc_id:                     "<computed>"
     zone_id:                    "<computed>"
         """.format(
-                compact_name=name[:32].strip('-'),
-                name=name
+                name=name[:32].strip('-'),
             ).strip() in output
 
     def test_create_alb_with_tags(self):
@@ -92,7 +90,6 @@ class TestTFALB(unittest.TestCase):
 + module.alb_test_with_tags.aws_alb.alb
     access_logs.#:              "1"
     access_logs.0.enabled:      "false"
-    access_logs.0.prefix:       "albalbalb"
     arn:                        "<computed>"
     arn_suffix:                 "<computed>"
     dns_name:                   "<computed>"

--- a/variables.tf
+++ b/variables.tf
@@ -37,6 +37,16 @@ variable "extra_security_groups" {
   default     = [""]
 }
 
+variable "access_logs_bucket" {
+  description = "An S3 bucket to send access logs to"
+  default     = ""
+}
+
+variable "access_logs_enabled" {
+  description = "Whether or not to enable access logs"
+  default     = false
+}
+
 variable "tags" {
   description = "A map of tags to add to all resources"
   default     = {}

--- a/variables.tf
+++ b/variables.tf
@@ -14,8 +14,8 @@ variable "subnet_ids" {
   type        = "list"
 }
 
-variable "certificate_arn" {
-  description = "The ARN of the SSL server certificate. Exactly one certificate is required if the protocol is HTTPS"
+variable "certificate_domain_name" {
+  description = "Domain name as used in AWS ACM Certificate - this will be used by Terraform Data Source to resolve the actual certificate ARN"
   type        = "string"
 }
 


### PR DESCRIPTION
We'd like to automatically ship access logs for ALBs but we need to make sure that this will be backwards compatible with all the uses of this module so disable it by default.